### PR TITLE
fix: make double-hash step always odd and non-zero

### DIFF
--- a/bbloom.go
+++ b/bbloom.go
@@ -81,11 +81,12 @@ func New(params ...float64) (bloomfilter *Bloom, err error) {
 	}
 	size, exponent := getSize(uint64(entries))
 	bloomfilter = &Bloom{
-		sizeExp: exponent,
-		size:    size - 1,
-		setLocs: locs,
-		shift:   64 - exponent,
-		bitset:  make([]uint64, size>>6),
+		sizeExp:     exponent,
+		size:        size - 1,
+		setLocs:     locs,
+		shift:       64 - exponent,
+		bitset:      make([]uint64, size>>6),
+		hashVersion: 1,
 	}
 	return bloomfilter, nil
 }
@@ -109,6 +110,7 @@ func NewWithBoolset(bs []byte, locs uint64) (bloomfilter *Bloom) {
 type bloomJSONImExport struct {
 	FilterSet []byte
 	SetLocs   uint64
+	Version   uint8 `json:"Version,omitempty"`
 }
 
 // Bloom is a bloom filter backed by a power-of-two sized bitset.
@@ -122,7 +124,8 @@ type Bloom struct {
 	setLocs uint64
 	shift   uint64
 
-	content uint64
+	content     uint64
+	hashVersion uint8 // 0 = legacy, 1 = l|=1 fix (issue #11)
 }
 
 // ElementsAdded returns the number of elements added to the bloom filter.
@@ -252,6 +255,7 @@ func (bl *Bloom) isSet(idx uint64) bool {
 func (bl *Bloom) marshal() bloomJSONImExport {
 	bloomImEx := bloomJSONImExport{}
 	bloomImEx.SetLocs = uint64(bl.setLocs)
+	bloomImEx.Version = bl.hashVersion
 	bloomImEx.FilterSet = make([]byte, len(bl.bitset)<<3)
 	for i, w := range bl.bitset {
 		binary.BigEndian.PutUint64(bloomImEx.FilterSet[i<<3:], w)
@@ -291,6 +295,7 @@ func JSONUnmarshal(dbData []byte) (*Bloom, error) {
 		return nil, err
 	}
 	bf := NewWithBoolset(bloomImEx.FilterSet, bloomImEx.SetLocs)
+	bf.hashVersion = bloomImEx.Version
 	return bf, nil
 }
 

--- a/bbloom_test.go
+++ b/bbloom_test.go
@@ -81,6 +81,83 @@ func TestM_JSON(t *testing.T) {
 		t.Errorf("FAILED !AddIfNotHas = %v; want %v", cnt2, shallBe)
 	}
 }
+func TestSipHashLowAlwaysOdd(t *testing.T) {
+	bf, err := New(float64(1<<20), float64(7))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := range 10000 {
+		entry := []byte("entry-" + strconv.Itoa(i))
+		l, _ := bf.sipHash(entry)
+		if l%2 == 0 {
+			t.Fatalf("l is even for entry %q: l=%d", entry, l)
+		}
+	}
+}
+
+func TestJSONBackwardCompatV0(t *testing.T) {
+	// simulate a filter created with the legacy hash (version 0)
+	bf, err := New(float64(n*10), float64(7))
+	if err != nil {
+		t.Fatal(err)
+	}
+	bf.hashVersion = 0 // legacy
+
+	entries := wordlist1[:1000]
+	for _, e := range entries {
+		bf.Add(e)
+	}
+
+	// serialize (will have Version:0 which is omitted from JSON)
+	data := bf.JSONMarshal()
+
+	// deserialize -- should restore version 0 and use legacy hash
+	bf2, err := JSONUnmarshal(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if bf2.hashVersion != 0 {
+		t.Fatalf("expected hashVersion 0, got %d", bf2.hashVersion)
+	}
+
+	for _, e := range entries {
+		if !bf2.Has(e) {
+			t.Fatalf("v0 filter lost entry %q after JSON round-trip", e)
+		}
+	}
+}
+
+func TestJSONRoundTripV1(t *testing.T) {
+	bf, err := New(float64(n*10), float64(7))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entries := wordlist1[:1000]
+	for _, e := range entries {
+		bf.Add(e)
+	}
+
+	data := bf.JSONMarshal()
+
+	bf2, err := JSONUnmarshal(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if bf2.hashVersion != 1 {
+		t.Fatalf("expected hashVersion 1, got %d", bf2.hashVersion)
+	}
+
+	for _, e := range entries {
+		if !bf2.Has(e) {
+			t.Fatalf("v1 filter lost entry %q after JSON round-trip", e)
+		}
+	}
+}
+
 func TestFillRatio(t *testing.T) {
 	bf, err := New(float64(512), float64(7))
 	if err != nil {

--- a/sipHash.go
+++ b/sipHash.go
@@ -220,6 +220,9 @@ func (bl *Bloom) sipHash(p []byte) (l, h uint64) {
 	hash := v0 ^ v1 ^ v2 ^ v3
 	h = hash >> bl.shift
 	l = hash << bl.shift >> bl.shift
+	if bl.hashVersion >= 1 {
+		l |= 1 // force odd so l is coprime to 2^sizeExp (issue #11)
+	}
 	return l, h
 
 }


### PR DESCRIPTION
- Closes #11

the bloom filter uses double-hashing to pick bit positions:

`position[i] = (h + i * l) % filterSize`

the old code split a siphash output into h (high bits) and l (low bits) without any correction. this had two problems:

1. when l was zero (~1 in 2^sizeExp chance per entry), every iteration picked the same bit, so only 1 bit was set instead of setLocs bits. this made the filter blind to that entry, raising the false positive rate.

2. when l was even (50% of entries), the step size shared a common factor with the power-of-two filter size, cutting the reachable positions in half. this weakened bit spread and increased false positives for those entries.

both problems also made it easier for an (hypothetical, does not matter in practice due to how we use it in IPFS) attacker who knows the (hardcoded) siphash keys to craft inputs that deliberately cluster bits and degrade the filter.

fix by setting the lowest bit: l |= 1. this guarantees l is odd and non-zero, so it is coprime to the filter size and all positions are reachable.

a hashVersion field (0 = old, 1 = fixed) is added to the Bloom struct and serialized in JSON so that existing filters loaded from disk keep working with the old hash.

- sipHash.go: set l |= 1 for hashVersion >= 1
- bbloom.go: new filters default to hashVersion 1, version is persisted in JSON (omitted when 0 for backward compat)
- bbloom_test.go: tests for odd-l guarantee and JSON round-trip for both v0 and v1 filters
